### PR TITLE
make ghaminer into a service

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,11 @@
+[packages]
+fastapi = "*"
+uvicorn = "*"
+pydantic = "*"
+requests = "*"
+numpy = "*"
+pyyaml = "*"
+pandas = "*"
+
+[scripts]
+ghaminer = "uvicorn src.main:app --reload --host 0.0.0.0 --port 8001"

--- a/src/GHAMetrics.py
+++ b/src/GHAMetrics.py
@@ -68,12 +68,15 @@ logging.getLogger('').addHandler(console)
 
 
 def load_config(config_file='config.yaml'):
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    config_path = os.path.join(script_dir, config_file)
     try:
-        with open(config_file, 'r') as file:
+        with open(config_path, 'r') as file:
             config = yaml.safe_load(file)
+            logging.info(f"[CONFIG] Loaded config from: {config_path}")
         return config
     except Exception as e:
-        logging.error(f"Failed to load config file {config_file}: {e}")
+        logging.error(f"Failed to load config file {config_path}: {e}")
         return {}
 
 

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -2,7 +2,7 @@
 fetch_job_details: true
 
 # Adds: tests_passed, tests_failed, tests_skipped, tests_total
-fetch_test_parsing_results: false
+fetch_test_parsing_results: true
 
 # Adds: gh_files_added, gh_files_deleted, gh_files_modified, file_types,
 #       gh_lines_added, gh_lines_deleted, gh_src_churn,
@@ -10,10 +10,9 @@ fetch_test_parsing_results: false
 #       gh_src_files, gh_doc_files, gh_other_files,
 #       gh_commits_on_files_touched, dockerfile_changed, docker_compose_changed,
 #       git_num_committers, git_commits, gh_team_size_last_3_month
-fetch_commit_details: false
-
+fetch_commit_details: true
 # Adds: gh_pull_req_number, gh_is_pr, gh_num_pr_comments, git_merged_with, gh_description_complexity
 fetch_pull_request_details: true
 
 # Adds: gh_sloc, gh_test_lines_per_kloc
-fetch_sloc: false
+fetch_sloc: true

--- a/src/main.py
+++ b/src/main.py
@@ -2,8 +2,17 @@ from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 import subprocess
 from pathlib import Path
-
+from fastapi.middleware.cors import CORSMiddleware
 app = FastAPI()
+
+# Add this after app instantiation
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],  # Use ["http://localhost:3000"] for stricter dev setup
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 class RunPayload(BaseModel):
     repo_url: str

--- a/src/main.py
+++ b/src/main.py
@@ -16,9 +16,9 @@ def health_check():
 @app.post("/run")
 def run_ghaminer(payload: RunPayload):
     repo = "/".join(payload.repo_url.rstrip("/").split("/")[-2:])
-    print(f"[GHAminer1 API] Fetching data for repo: {repo}")
+    print(f"[GHAminer API] Fetching data for repo: {repo}")
 
-    ghametrics_path = Path(__file__).resolve().parent / "GHAMetrics.py"
+    ghametrics_path = Path(__file__).resolve().parent.parent / "src" / "GHAMetrics.py"
 
     if not ghametrics_path.exists():
         raise HTTPException(
@@ -48,7 +48,7 @@ def run_ghaminer(payload: RunPayload):
         raise HTTPException(
             status_code=500,
             detail={
-                "error": "GHAminer1 execution failed",
+                "error": "GHAminer execution failed",
                 "repo": repo,
                 "stderr": e.stderr.strip()
             }

--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 import subprocess
-import os
+from pathlib import Path
 
 app = FastAPI()
 
@@ -14,15 +14,22 @@ def health_check():
     return {"status": "ok"}
 
 @app.post("/run")
-@app.post("/run")
 def run_ghaminer(payload: RunPayload):
-    repo = payload.repo_url.split("/")[-2] + "/" + payload.repo_url.split("/")[-1]
-    print(f"[GHAminer1 API] Fetching data for repo: {repo}")  # 👈 add this line
+    repo = "/".join(payload.repo_url.rstrip("/").split("/")[-2:])
+    print(f"[GHAminer1 API] Fetching data for repo: {repo}")
+
+    ghametrics_path = Path(__file__).resolve().parent / "GHAMetrics.py"
+
+    if not ghametrics_path.exists():
+        raise HTTPException(
+            status_code=500,
+            detail=f"GHAMetrics.py not found at: {ghametrics_path}"
+        )
 
     try:
         result = subprocess.run(
             [
-                "python", "GHAMetrics.py",
+                "python3", str(ghametrics_path),
                 "--token", payload.token,
                 "--single-project", payload.repo_url
             ],

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,48 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+import subprocess
+import os
+
+app = FastAPI()
+
+class RunPayload(BaseModel):
+    repo_url: str
+    token: str
+
+@app.get("/")
+def health_check():
+    return {"status": "ok"}
+
+@app.post("/run")
+@app.post("/run")
+def run_ghaminer(payload: RunPayload):
+    repo = payload.repo_url.split("/")[-2] + "/" + payload.repo_url.split("/")[-1]
+    print(f"[GHAminer1 API] Fetching data for repo: {repo}")  # 👈 add this line
+
+    try:
+        result = subprocess.run(
+            [
+                "python", "GHAMetrics.py",
+                "--token", payload.token,
+                "--single-project", payload.repo_url
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=True
+        )
+        return {
+            "status": "success",
+            "repo": repo,
+            "stdout": result.stdout
+        }
+
+    except subprocess.CalledProcessError as e:
+        raise HTTPException(
+            status_code=500,
+            detail={
+                "error": "GHAminer1 execution failed",
+                "repo": repo,
+                "stderr": e.stderr.strip()
+            }
+        )


### PR DESCRIPTION
### Summary

This PR refactors GHAMiner into a standalone FastAPI service to enable programmatic triggering over HTTP instead of CLI execution. This decoupling aligns with microservice architecture goals and enables integration into external CI/CD observability pipelines.

### Changes Made

- Introduced FastAPI app at src/main.py:
- GET /health: Liveness probe
- POST /run: Accepts repo_url and token, runs GHAMetrics.py

### How to Test

- Start the service:
```
pipenv install  # if not done already
```
```
pipenv run ghaminer
```
